### PR TITLE
fix hashCode bug

### DIFF
--- a/lib/src/word_pair.dart
+++ b/lib/src/word_pair.dart
@@ -169,7 +169,7 @@ class WordPair {
   String get asUpperCase => _asUpperCase ??= asString.toUpperCase();
 
   @override
-  int get hashCode => asString.hashCode;
+  int get hashCode => (first.hashCode.toString() + second.hashCode.toString()).hashCode;
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
if hashCode is `asString.hashCode` then the hashCode of `{first: 'AB', second: 'CD'}` is the same with `{first: 'ABC', second: 'D'}`